### PR TITLE
comment out link to cgc meeting url until the url is correct.

### DIFF
--- a/collections/_meetings/20240803-unconference.md
+++ b/collections/_meetings/20240803-unconference.md
@@ -20,7 +20,7 @@ To view proposed topics or suggest an idea, visit the [GitHub Issues page](https
 
 *When:*\
 8am-5pm Saturday, August 3rd\
-For more details, please see: https://www.cancergenomics.org/meetings/2023_vicc_civic_clingen_hackat.php
+<!---For more details, please see: https://www.cancergenomics.org/meetings/2023_vicc_civic_clingen_hackat.php-->
 
 *Where:*\
 Hyatt Regency St. Louis at the Arch


### PR DESCRIPTION
Commented out the cgc meeting link since the new url doesnt exist yet. 